### PR TITLE
[Cycode] Fix for IaC misconfiguration - The default namespace should not be used

### DIFF
--- a/application-workloads/jenkins/jenkins-cicd-container/kubernetes/hello-world-service.yaml
+++ b/application-workloads/jenkins/jenkins-cicd-container/kubernetes/hello-world-service.yaml
@@ -2,9 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello-world-service
+  namespace: value
 spec:
   type: LoadBalancer
   ports:
-  - port: 80
+    - port: 80
   selector:
     app: hello-world


### PR DESCRIPTION
[Cycode] Fix for IaC misconfiguration - The default namespace should not be used